### PR TITLE
Fix patient data owner corruption on first login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,19 @@
+# 1.5.2
+
+- Fix a bug that caused corruption of the Patient entity data the first time the new patient user logins through the
+  authentication API.
+- Includes new methods that allow new Patient users which didn't yet receive access to their existing data to still be
+  able to create new data samples and healthcare elements
+
 # 1.5.1
-- [MDT-175](https://icure.atlassian.net/browse/MDT-175) BUG : Resolve 400 Invalid Patient bug during patient authentication
+
+- [MDT-175](https://icure.atlassian.net/browse/MDT-175) BUG : Resolve 400 Invalid Patient bug during patient
+  authentication
 - BUG : Resolve 500 Base64 error due to defected cache when completing patient authentication
 - BUG : Resolve race condition when calling updateUser service
 
 # 1.5.0
+
 - Add Check to bypass token in case a user need to use authentication instead (Google Store submission)
 - Enable authentication by SMS
 

--- a/lib/api/impl/healthcare_element_api_impl.dart
+++ b/lib/api/impl/healthcare_element_api_impl.dart
@@ -32,9 +32,14 @@ class HealthcareElementApiImpl extends HealthcareElementApi {
       return modifiedHealthElementDto != null ? HealthElementDtoMapper(modifiedHealthElementDto).toHealthcareElement() : null;
     }
 
-    final patient = await api.basePatientApi.getPatient(currentUser, patientId, ccPatient) ?? (throw StateError("Patient not found"));
-    final createdHealthElementDto = await api.baseHealthElementApi
-        .createHealthElementWithPatient(currentUser, patient, HealthcareElementMapper(healthcareElement).toHealthElementDto(), ccHealthElement);
+    final patient = await api.patientApi.getPatientAndTryDecrypt(patientId) ?? (throw StateError("Patient not found"));
+    final createdHealthElementDto = await api.baseHealthElementApi.createHealthElementWithPatientInfo(
+      currentUser,
+      patient.id!,
+      (patient.systemMetaData?.delegations ?? {}).toDelegationMapDto(),
+      HealthcareElementMapper(healthcareElement).toHealthElementDto(),
+      ccHealthElement
+    );
     return createdHealthElementDto != null ? HealthElementDtoMapper(createdHealthElementDto).toHealthcareElement() : null;
   }
 
@@ -55,9 +60,14 @@ class HealthcareElementApiImpl extends HealthcareElementApi {
     final healthElementDtosToUpdate = healthcareElementsToUpdate.map((e) => e.toHealthElementDto()).toList();
     final healthElementDtosToCreate = healthcareElementsToCreate.map((e) => e.toHealthElementDto()).toList();
 
-    final patient =
-        await base_api.PatientApiCrypto(api.basePatientApi).getPatient(currentUser!, patientId, ccPatient) ?? (throw StateError("Patient not found"));
-    final heCreated = await api.baseHealthElementApi.createHealthElements(currentUser, patient, healthElementDtosToCreate, ccHealthElement);
+    final patient = await api.patientApi.getPatientAndTryDecrypt(patientId) ?? (throw StateError("Patient not found"));
+    final heCreated = await api.baseHealthElementApi.createHealthElementsWithPatientInfo(
+        currentUser!,
+        patient.id!,
+        patient.systemMetaData!.delegations.toDelegationMapDto(),
+        healthElementDtosToCreate,
+        ccHealthElement
+    );
     final heUpdated = await api.baseHealthElementApi.modifyHealthElements(currentUser, healthElementDtosToUpdate, ccHealthElement);
     final heProcessed = [...?heCreated, ...heUpdated];
 
@@ -109,37 +119,41 @@ class HealthcareElementApiImpl extends HealthcareElementApi {
       throw StateError("DataOwner ${currentUser!.dataOwnerId()} does not have the right to access healthcare element ${healthcareElement.id}");
     }
 
-    // Check if delegatedTo already has access
-    if (healthcareElement.systemMetaData!.delegations.entries.any((element) => element.key == delegatedTo)) {
+    final myId = currentUser!.dataOwnerId()!;
+    final healthcareElementDto = healthcareElement.toHealthElementDto();
+    final patientId = (await localCrypto.decryptEncryptionKeys(myId, healthcareElementDto.cryptedForeignKeys)).firstOrNull!.formatAsKey();
+    final newSecretIds = await localCrypto.findAndDecryptPotentiallyUnknownKeysForDelegate(myId, delegatedTo, healthcareElementDto.delegations);
+    final newEncryptionKeys = await localCrypto.findAndDecryptPotentiallyUnknownKeysForDelegate(myId, delegatedTo, healthcareElementDto.encryptionKeys);
+    final newCfks = await localCrypto.findAndDecryptPotentiallyUnknownKeysForDelegate(myId, delegatedTo, healthcareElementDto.cryptedForeignKeys);
+
+    if (newSecretIds.isEmpty && newEncryptionKeys.isEmpty && newCfks.isEmpty) {
       return healthcareElement;
     }
 
-    final healthcareElementDto = healthcareElement.toHealthElementDto();
-
-    final patientId =
-        (await localCrypto.decryptEncryptionKeys(currentUser!.dataOwnerId()!, healthcareElementDto.cryptedForeignKeys)).firstOrNull!.formatAsKey();
-    final sfk = (await localCrypto.decryptEncryptionKeys(currentUser.dataOwnerId()!, healthcareElementDto.delegations)).firstOrNull!.formatAsKey();
-    final ek = (await localCrypto.decryptEncryptionKeys(currentUser.dataOwnerId()!, healthcareElementDto.encryptionKeys)).firstOrNull!.formatAsKey();
-
-    final delegation = await DelegationExtended.delegationBasedOn(localCrypto, currentUser.dataOwnerId()!, delegatedTo, healthcareElement.id!, sfk);
+    final newSecretIdsDelegations = await Future.wait(newSecretIds.map((clearKey) =>
+        DelegationExtended.delegationBasedOn(localCrypto, myId, delegatedTo, healthcareElement.id!, clearKey.formatAsKey())
+    ));
+    final newEncryptionKeysDelegations = await Future.wait(newEncryptionKeys.map((clearKey) =>
+        DelegationExtended.delegationBasedOn(localCrypto, myId, delegatedTo, healthcareElement.id!, clearKey.formatAsKey())
+    ));
+    final newCfksDelegations = await Future.wait(newCfks.map((clearKey) =>
+        DelegationExtended.delegationBasedOn(localCrypto, myId, delegatedTo, healthcareElement.id!, clearKey.formatAsKey())
+    ));
 
     if (healthcareElement.systemMetaData == null) {
-      healthcareElement.systemMetaData = SystemMetaDataEncrypted(delegations: {
-        delegatedTo: [delegation]
-      });
-    } else {
-      healthcareElement.systemMetaData!.delegations = {...healthcareElement.systemMetaData!.delegations}..addEntries([
-          MapEntry(delegatedTo, [delegation])
-        ]);
+      healthcareElement.systemMetaData = SystemMetaDataEncrypted(
+        delegations: {},
+        cryptedForeignKeys: {},
+        encryptionKeys: {}
+      );
     }
 
-    healthcareElement.systemMetaData!.encryptionKeys = {...healthcareElement.systemMetaData!.encryptionKeys}..addEntries([
-        MapEntry(delegatedTo, [await DelegationExtended.delegationBasedOn(localCrypto, currentUser.dataOwnerId()!, delegatedTo, healthcareElement.id!, ek)])
-      ]);
-
-    healthcareElement.systemMetaData!.cryptedForeignKeys = {...healthcareElement.systemMetaData!.cryptedForeignKeys}..addEntries([
-        MapEntry(delegatedTo, [ await DelegationExtended.delegationBasedOn(localCrypto, currentUser.dataOwnerId()!, delegatedTo, healthcareElement.id!, patientId)])
-      ]);
+    final existingDelegationsForDelegate = healthcareElement.systemMetaData!.delegations[delegatedTo] ?? [];
+    healthcareElement.systemMetaData!.delegations[delegatedTo] = [...existingDelegationsForDelegate, ...newSecretIdsDelegations];
+    final existingEncryptionKeysForDelegate = healthcareElement.systemMetaData!.encryptionKeys[delegatedTo] ?? [];
+    healthcareElement.systemMetaData!.encryptionKeys[delegatedTo] = [...existingEncryptionKeysForDelegate, ...newEncryptionKeysDelegations];
+    final existingCfksForDelegate = healthcareElement.systemMetaData!.cryptedForeignKeys[delegatedTo] ?? [];
+    healthcareElement.systemMetaData!.cryptedForeignKeys[delegatedTo] = [...existingCfksForDelegate, ...newCfksDelegations];
 
     return (await createOrModifyHealthcareElement(patientId, healthcareElement)) ??
         (throw StateError("Couldn't give access to $delegatedTo to health element ${healthcareElement.id}"));

--- a/lib/api/impl/patient_api_impl.dart
+++ b/lib/api/impl/patient_api_impl.dart
@@ -71,48 +71,75 @@ class PatientApiImpl extends PatientApi {
       throw StateError("DataOwner ${currentUser!.dataOwnerId()} does not have the right to access patient ${patient.id}");
     }
 
-    // Check if delegatedTo already has access
-    if (patient.systemMetaData!.delegations.entries.any((element) => element.key == delegatedTo)) {
+    final patientDto = patient.toPatientDto();
+
+    final myId = currentUser!.dataOwnerId()!;
+    final newSecretIds = await localCrypto.findAndDecryptPotentiallyUnknownKeysForDelegate(myId, delegatedTo, patientDto.delegations);
+    final newEncryptionKeys = await localCrypto.findAndDecryptPotentiallyUnknownKeysForDelegate(myId, delegatedTo, patientDto.encryptionKeys);
+
+    if (newSecretIds.isEmpty && newSecretIds.isEmpty) {
       return patient;
     }
 
-    final patientDto = patient.toPatientDto();
-
-    final keyAndOwner = await localCrypto.encryptAESKeyForHcp(currentUser!.dataOwnerId()!, delegatedTo, patientDto.id,
-        (await localCrypto.decryptEncryptionKeys(currentUser.dataOwnerId()!, patientDto.delegations)).firstOrNull!.formatAsKey());
-    final delegation = Delegation(owner: currentUser.dataOwnerId(), delegatedTo: delegatedTo, key: keyAndOwner.item1);
+    DataOwnerDto? dataOwner = null;
+    final Map<String, String> encryptedKeys = {};
+    for (var clearKey in { ...newSecretIds, ...newEncryptionKeys }) {
+      final encryptedKeyAndOwner = await localCrypto.encryptAESKeyForHcp(
+          myId,
+          delegatedTo,
+          patientDto.id,
+          clearKey.formatAsKey()
+      );
+      encryptedKeys[clearKey] = encryptedKeyAndOwner.item1;
+      dataOwner = encryptedKeyAndOwner.item2 ?? dataOwner;
+    }
+    final newSecretIdsDelegations = newSecretIds.map((clearKey) =>
+        Delegation(owner: myId, delegatedTo: delegatedTo, key: encryptedKeys[clearKey]!)
+    );
+    final newEncryptionKeysDelegations = newEncryptionKeys.map((clearKey) =>
+        Delegation(owner: myId, delegatedTo: delegatedTo, key: encryptedKeys[clearKey]!)
+    );
 
     if (patient.systemMetaData == null) {
-      patient.systemMetaData = SystemMetaDataOwnerEncrypted(delegations: {
-        delegatedTo: [delegation]
-      });
-    } else {
-      patient.systemMetaData!.delegations = {...patient.systemMetaData!.delegations}..addEntries([
-          MapEntry(delegatedTo, [delegation])
-        ]);
+      patient.systemMetaData = SystemMetaDataOwnerEncrypted(delegations: {}, encryptionKeys: {});
     }
+    final existingDelegationsForDelegate = patient.systemMetaData!.delegations[delegatedTo] ?? [];
+    patient.systemMetaData!.delegations[delegatedTo] = [...existingDelegationsForDelegate, ...newSecretIdsDelegations];
+    final existingEncryptionKeysForDelegate = patient.systemMetaData!.encryptionKeys[delegatedTo] ?? [];
+    patient.systemMetaData!.encryptionKeys[delegatedTo] = [...existingEncryptionKeysForDelegate, ...newEncryptionKeysDelegations];
 
-    patient.systemMetaData!.encryptionKeys = {...patient.systemMetaData!.encryptionKeys}..addEntries([
-        MapEntry(delegatedTo, [
-          await DelegationExtended.delegationBasedOn(localCrypto, currentUser.dataOwnerId()!, delegatedTo, patient.id!,
-              (await localCrypto.decryptEncryptionKeys(currentUser.dataOwnerId()!, patientDto.encryptionKeys)).firstOrNull!.formatAsKey())
-        ])
-      ]);
-
-    final dataOwner = keyAndOwner.item2;
     if (dataOwner != null && dataOwner.dataOwnerId == patient.id) {
       patient.rev = dataOwner.rev;
       patient.systemMetaData!.hcPartyKeys = dataOwner.hcPartyKeys;
+      patient.systemMetaData!.aesExchangeKeys = dataOwner.aesExchangeKeys;
     }
 
     return (await createOrModifyPatient(patient)) ?? (throw StateError("Couldn't give access to $delegatedTo to patient ${patient.id}"));
   }
 
-  Future<Delegation> createDelegationBasedOn(Crypto localCrypto, String dataOwnerId,
-      String delegatedTo, String objectId, String keyToEncrypt) async {
-    return Delegation(
-        owner: dataOwnerId,
-        delegatedTo: delegatedTo,
-        key: (await localCrypto.encryptAESKeyForHcp(dataOwnerId, delegatedTo, objectId, keyToEncrypt)).item1);
+  @override
+  Future<PotentiallyEncryptedPatient?> getPatientAndTryDecrypt(String patientId) async {
+    final patient = await _api.basePatientApi.rawGetPatient(patientId);
+    if (patient == null) return null;
+    final config = patientCryptoConfig(_api.crypto);
+    final currentUser = (await _api.baseUserApi.getCurrentUser() ?? (throw StateError("Couldn't get current user")));
+    try {
+      return PatientDtoMapper(await config.decryptPatient(currentUser.dataOwnerId()!, patient)).toPatient();
+    } catch (e) {
+      return EncryptedPatientDtoMapper(patient).toEncryptedPatient();
+    }
+  }
+
+  @override
+  Future<EncryptedPatient?> modifyEncryptedPatient(EncryptedPatient modifiedPatient) async {
+    final config = patientCryptoConfig(_api.crypto);
+    final rawDto = EncryptedPatientMapper(modifiedPatient).toPatientDto();
+    final asDecrypted = DecryptedPatientDto.fromJson(rawDto.toJson());
+    if (asDecrypted == null || (await config.marshaller(asDecrypted)).item2 != null) {
+      throw ArgumentError('Impossible to modify non-decryptable patient if new data requires encryption');
+    }
+    final modified = await _api.basePatientApi.rawModifyPatient(rawDto);
+    if (modified == null) return null;
+    return EncryptedPatientDtoMapper(modified).toEncryptedPatient();
   }
 }

--- a/lib/api/patient_api.dart
+++ b/lib/api/patient_api.dart
@@ -84,4 +84,17 @@ abstract class PatientApi {
   /// * deviceId
   ///
   Future<Patient> giveAccessTo(Patient patient, String delegatedTo);
+
+  /// Gets a patient and tries to decrypt its content. If it is not possible to decrypt the content only the unencrypted
+  /// data will be available.
+  /// This method is useful to allow new patient users to access some of their own data before their doctor actually
+  /// gave them access to their own data: instead of giving an error if the data can't be decrypted (like what happens
+  /// in getPatient) you will be able to get at least partial information.
+  Future<PotentiallyEncryptedPatient?> getPatientAndTryDecrypt(String patientId,);
+
+  /// Modifies an encrypted patient, ensuring that the modified patient does not include any data which should be
+  /// encrypted.
+  /// Similarly to getPatientAndTryDecrypt this method is useful when a patient needs to update is own data before
+  /// an hcp gave him access to his own encrypted data.
+  Future<EncryptedPatient?> modifyEncryptedPatient(EncryptedPatient modifiedPatient,);
 }

--- a/lib/filter/filter_dsl.dart
+++ b/lib/filter/filter_dsl.dart
@@ -419,7 +419,7 @@ class DataSampleFilter extends FilterBuilder<DataSample> {
       await _forPatients?.let((v) async {
         var localCrypto = v.item1;
         Set<String> secretForeignKeys = (await Future.wait(v.item2.map((p) {
-          var delegations = (p.systemMetaData?.delegations ?? {}).map((k, v) => MapEntry(k, v.map((d) => d.toDelegationDto()).toSet()));
+          var delegations = (p.systemMetaData?.delegations ?? {}).toDelegationMapDto();
           return localCrypto.decryptEncryptionKeys(dataOwnerId, delegations);
         })))
             .toSet()

--- a/lib/mappers/delegation.dart
+++ b/lib/mappers/delegation.dart
@@ -18,3 +18,13 @@ extension DelegationMapper on Delegation {
 extension DelegationDtoMapper on DelegationDto {
   Delegation toDelegation() => Delegation(tags: this.tags, owner: this.owner, delegatedTo: this.delegatedTo, key: this.key);
 }
+
+extension DelegationMapMapper on Map<String, List<Delegation>> {
+  Map<String, Set<DelegationDto>> toDelegationMapDto() =>
+    { for (final entry in this.entries) entry.key : entry.value.map((e) => e.toDelegationDto()).toSet() };
+}
+
+extension DelegationMapDtoMapper on Map<String, Set<DelegationDto>> {
+  Map<String, List<Delegation>> toDelegationMap() =>
+      { for (final entry in this.entries) entry.key : entry.value.map((e) => e.toDelegation()).toList() };
+}

--- a/lib/mappers/patient.dart
+++ b/lib/mappers/patient.dart
@@ -92,6 +92,73 @@ extension PatientDtoMapper on DecryptedPatientDto {
           )
       );
 }
+
+extension EncryptedPatientDtoMapper on PatientDto {
+  EncryptedPatient toEncryptedPatient() =>
+      EncryptedPatient(
+          id: this.id,
+          identifiers: this.identifier.map((it) => it.toIdentifier()).toList(),
+          labels: this.tags.map((it) => it.toCodingReference()).toSet(),
+          codes: this.codes.map((it) => it.toCodingReference()).toSet(),
+          names: this.names.map((it) => it.toPersonName()).toList(),
+          languages: this.languages,
+          addresses: this.addresses.map((it) => it.toAddress()).toList(),
+          mergedIds: this.mergedIds,
+          active: this.active,
+          deactivationReason: this.deactivationReason?.toDeactivationReason() ?? PatientDeactivationReasonEnum.none,
+          partnerships: this.partnerships.map((it) => it.toPartnership()).toList(),
+          patientHealthCareParties: this.patientHealthCareParties.map((it) => it.toPatientHealthCareParty()).toList(),
+          patientProfessions: this.patientProfessions.map((it) => it.toCodingReference()).toList(),
+          parameters: this.parameters,
+          properties: this.properties.map((it) => it.toProperty()).toSet(),
+          rev: this.rev,
+          created: this.created,
+          modified: this.modified,
+          author: this.author,
+          responsible: this.responsible,
+          endOfLife: this.endOfLife,
+          deletionDate: this.deletionDate,
+          firstName: this.firstName,
+          lastName: this.lastName,
+          companyName: this.companyName,
+          civility: this.civility,
+          gender: this.gender?.toGender(),
+          birthSex: this.birthSex?.toBirthSex(),
+          mergeToPatientId: this.mergeToPatientId,
+          alias: this.alias,
+          ssin: this.ssin,
+          maidenName: this.maidenName,
+          spouseName: this.spouseName,
+          partnerName: this.partnerName,
+          personalStatus: this.personalStatus?.toPersonalStatus(),
+          dateOfBirth: this.dateOfBirth,
+          dateOfDeath: this.dateOfDeath,
+          placeOfBirth: this.placeOfBirth,
+          placeOfDeath: this.placeOfDeath,
+          deceased: this.deceased,
+          education: this.education,
+          profession: this.profession,
+          note: this.note,
+          administrativeNote: this.administrativeNote,
+          nationality: this.nationality,
+          race: this.race,
+          ethnicity: this.ethnicity,
+          picture: this.picture,
+          externalId: this.externalId,
+          systemMetaData: SystemMetaDataOwnerEncrypted(
+            publicKey: this.publicKey,
+            hcPartyKeys: this.hcPartyKeys,
+            privateKeyShamirPartitions: this.privateKeyShamirPartitions,
+            secretForeignKeys: this.secretForeignKeys.toList(),
+            cryptedForeignKeys: this.cryptedForeignKeys.map((k, v) => MapEntry(k, v.map((it) => it.toDelegation()).toList())) ,
+            delegations: this.delegations.map((k, v) => MapEntry(k, v.map((it) => it.toDelegation()).toList())),
+            encryptionKeys: this.encryptionKeys.map((k, v) => MapEntry(k, v.map((it) => it.toDelegation()).toList())),
+            aesExchangeKeys: this.aesExchangeKeys,
+            transferKeys: this.transferKeys,
+          )
+      );
+}
+
 extension PatientDtoDeactivationReasonEnumMapper on PatientDtoDeactivationReasonEnum {
   PatientDeactivationReasonEnum toDeactivationReason() => PatientDeactivationReasonEnum.values.firstWhere((it) => it.value == this.value, orElse: () => PatientDeactivationReasonEnum.none);
 }
@@ -166,7 +233,7 @@ extension PatientMapper on Patient {
         privateKeyShamirPartitions: this.systemMetaData?.privateKeyShamirPartitions ?? const {},
         secretForeignKeys: this.systemMetaData?.secretForeignKeys.toSet() ?? {},
         cryptedForeignKeys:
-            this.systemMetaData?.cryptedForeignKeys.map((k, v) => MapEntry(k, v.map((it) => it.toDelegationDto()).toSet())) ?? const {},
+        this.systemMetaData?.cryptedForeignKeys.map((k, v) => MapEntry(k, v.map((it) => it.toDelegationDto()).toSet())) ?? const {},
         delegations: this.systemMetaData?.delegations.map((k, v) => MapEntry(k, v.map((it) => it.toDelegationDto()).toSet())) ?? const {},
         encryptionKeys: this.systemMetaData?.encryptionKeys.map((k, v) => MapEntry(k, v.map((it) => it.toDelegationDto()).toSet())) ?? const {},
         aesExchangeKeys: this.systemMetaData?.aesExchangeKeys ?? const {},
@@ -175,6 +242,75 @@ extension PatientMapper on Patient {
 
   DataOwnerDto toDataOwnerDto() =>
       DataOwnerDto(DataOwnerType.patient, this.id!, this.systemMetaData?.hcPartyKeys ?? const {}, publicKey: this.systemMetaData?.publicKey, rev: this.rev);
+}
+
+extension EncryptedPatientMapper on EncryptedPatient {
+  PatientDto toPatientDto() =>
+      PatientDto(
+        id: this.id?.also((it) {
+          if (!Uuid.isValidUUID(fromString: it)) {
+            throw FormatException("Invalid id, id must be a valid UUID");
+          }
+        }) ?? uuid.v4(options: {'rng': UuidUtil.cryptoRNG}),
+        identifier: this.identifiers.map((it) => it.toIdentifierDto()).toList(),
+        tags: this.labels.map((it) => it.toCodeStubDto()).toSet(),
+        codes: this.codes.map((it) => it.toCodeStubDto()).toSet(),
+        names: this.names.map((it) => it.toPersonNameDto()).toList(),
+        languages: this.languages,
+        addresses: this.addresses.map((it) => it.toAddressDto()).toList(),
+        mergedIds: this.mergedIds,
+        active: this.active,
+        deactivationReason: this.deactivationReason.toDeactivationReason(),
+        partnerships: this.partnerships.map((it) => it.toPartnershipDto()).toList(),
+        patientHealthCareParties: this.patientHealthCareParties.map((it) => it.toPatientHealthCarePartyDto()).toList(),
+        patientProfessions: this.patientProfessions.map((it) => it.toCodeStubDto()).toList(),
+        parameters: this.parameters,
+        properties: this.properties.map((it) => it.toPropertyStubDto()).toSet(),
+        rev: this.rev,
+        created: this.created,
+        modified: this.modified,
+        author: this.author,
+        responsible: this.responsible,
+        endOfLife: this.endOfLife,
+        deletionDate: this.deletionDate,
+        firstName: this.firstName,
+        lastName: this.lastName,
+        companyName: this.companyName,
+        civility: this.civility,
+        gender: this.gender?.toGender(),
+        birthSex: this.birthSex?.toBirthSex(),
+        mergeToPatientId: this.mergeToPatientId,
+        alias: this.alias,
+        ssin: this.ssin,
+        maidenName: this.maidenName,
+        spouseName: this.spouseName,
+        partnerName: this.partnerName,
+        personalStatus: this.personalStatus?.toPersonalStatus(),
+        dateOfBirth: this.dateOfBirth,
+        dateOfDeath: this.dateOfDeath,
+        placeOfBirth: this.placeOfBirth,
+        placeOfDeath: this.placeOfDeath,
+        deceased: this.deceased,
+        education: this.education,
+        profession: this.profession,
+        note: this.note,
+        administrativeNote: this.administrativeNote,
+        nationality: this.nationality,
+        race: this.race,
+        ethnicity: this.ethnicity,
+        picture: this.picture,
+        externalId: this.externalId,
+        publicKey: this.systemMetaData?.publicKey,
+        hcPartyKeys: this.systemMetaData?.hcPartyKeys ?? const {},
+        privateKeyShamirPartitions: this.systemMetaData?.privateKeyShamirPartitions ?? const {},
+        secretForeignKeys: this.systemMetaData?.secretForeignKeys.toSet() ?? {},
+        cryptedForeignKeys:
+        this.systemMetaData?.cryptedForeignKeys.map((k, v) => MapEntry(k, v.map((it) => it.toDelegationDto()).toSet())) ?? const {},
+        delegations: this.systemMetaData?.delegations.map((k, v) => MapEntry(k, v.map((it) => it.toDelegationDto()).toSet())) ?? const {},
+        encryptionKeys: this.systemMetaData?.encryptionKeys.map((k, v) => MapEntry(k, v.map((it) => it.toDelegationDto()).toSet())) ?? const {},
+        aesExchangeKeys: this.systemMetaData?.aesExchangeKeys ?? const {},
+        transferKeys: this.systemMetaData?.transferKeys ?? const {},
+      );
 }
 
 extension PatientDeactivationReasonEnumMapper on PatientDeactivationReasonEnum {

--- a/lib/model/patient.dart
+++ b/lib/model/patient.dart
@@ -10,7 +10,7 @@
 
 part of icure_medical_device_dart_sdk.api;
 
-class Patient {
+class Patient implements PotentiallyEncryptedPatient {
 
   /// Returns a new [Patient] instance.
   Patient({
@@ -66,593 +66,6 @@ class Patient {
     this.systemMetaData,
   });
 
-  /// the Id of the patient. We encourage using either a v4 UUID or a HL7 Id.
-  ///
-  /// Please note: This property should have been non-nullable! Since the specification file
-  /// does not include a default value (using the "default:" property), however, the generated
-  /// source code must fall back to having a nullable type.
-  /// Consider adding a "default:" property in the specification file to hide this note.
-  ///
-  String? id;
-
-  /// the revision of the patient in the database, used for conflict management / optimistic locking.
-  ///
-  /// Please note: This property should have been non-nullable! Since the specification file
-  /// does not include a default value (using the "default:" property), however, the generated
-  /// source code must fall back to having a nullable type.
-  /// Consider adding a "default:" property in the specification file to hide this note.
-  ///
-  String? rev;
-
-  /// Typically used for business / client identifiers. An identifier should identify a patient uniquely and unambiguously. However, iCure can't guarantee the uniqueness of those identifiers : This is something you need to take care of.
-  List<Identifier> identifiers;
-
-  /// the creation date of the patient (encoded as epoch).
-  ///
-  /// Please note: This property should have been non-nullable! Since the specification file
-  /// does not include a default value (using the "default:" property), however, the generated
-  /// source code must fall back to having a nullable type.
-  /// Consider adding a "default:" property in the specification file to hide this note.
-  ///
-  int? created;
-
-  /// the last modification date of the patient (encoded as epoch).
-  ///
-  /// Please note: This property should have been non-nullable! Since the specification file
-  /// does not include a default value (using the "default:" property), however, the generated
-  /// source code must fall back to having a nullable type.
-  /// Consider adding a "default:" property in the specification file to hide this note.
-  ///
-  int? modified;
-
-  /// The id of the [User] that created this patient. When creating the patient, this field will be filled automatically by the current user id if not provided.
-  ///
-  /// Please note: This property should have been non-nullable! Since the specification file
-  /// does not include a default value (using the "default:" property), however, the generated
-  /// source code must fall back to having a nullable type.
-  /// Consider adding a "default:" property in the specification file to hide this note.
-  ///
-  String? author;
-
-  /// The id of the data owner that is responsible of this patient. When creating the patient, will be filled automatically by the current user data owner id ([HealthcareProfessional], [Patient] or [MedicalDevice]) if missing
-  ///
-  /// Please note: This property should have been non-nullable! Since the specification file
-  /// does not include a default value (using the "default:" property), however, the generated
-  /// source code must fall back to having a nullable type.
-  /// Consider adding a "default:" property in the specification file to hide this note.
-  ///
-  String? responsible;
-
-  /// A label is an item from a codification system that qualifies a patient as being member of a certain class, whatever the value it might have taken. If the label qualifies the content of a field, it means that whatever the content of the field, the label will always apply. LOINC is a codification system typically used for labels.
-  Set<CodingReference> labels;
-
-  /// A code is an item from a codification system that qualifies the content of this patient.
-  Set<CodingReference> codes;
-
-  /// Soft delete (unix epoch in ms) timestamp of the patient
-  ///
-  /// Please note: This property should have been non-nullable! Since the specification file
-  /// does not include a default value (using the "default:" property), however, the generated
-  /// source code must fall back to having a nullable type.
-  /// Consider adding a "default:" property in the specification file to hide this note.
-  ///
-  int? endOfLife;
-
-  /// the soft delete timestamp. When a patient is ”deleted“, this is set to a non null value: the moment of the deletion
-  ///
-  /// Please note: This property should have been non-nullable! Since the specification file
-  /// does not include a default value (using the "default:" property), however, the generated
-  /// source code must fall back to having a nullable type.
-  /// Consider adding a "default:" property in the specification file to hide this note.
-  ///
-  int? deletionDate;
-
-  /// the firstname (name) of the patient.
-  ///
-  /// Please note: This property should have been non-nullable! Since the specification file
-  /// does not include a default value (using the "default:" property), however, the generated
-  /// source code must fall back to having a nullable type.
-  /// Consider adding a "default:" property in the specification file to hide this note.
-  ///
-  String? firstName;
-
-  /// the lastname (surname) of the patient. This is the official lastname that should be used for official administrative purposes.
-  ///
-  /// Please note: This property should have been non-nullable! Since the specification file
-  /// does not include a default value (using the "default:" property), however, the generated
-  /// source code must fall back to having a nullable type.
-  /// Consider adding a "default:" property in the specification file to hide this note.
-  ///
-  String? lastName;
-
-  /// the list of all names of the patient, also containing the official full name information. Ordered by preference of use. First element is therefore the official name used for the patient in the application
-  List<PersonName> names;
-
-  /// the name of the company this patient is member of.
-  ///
-  /// Please note: This property should have been non-nullable! Since the specification file
-  /// does not include a default value (using the "default:" property), however, the generated
-  /// source code must fall back to having a nullable type.
-  /// Consider adding a "default:" property in the specification file to hide this note.
-  ///
-  String? companyName;
-
-  /// the list of languages spoken by the patient ordered by fluency (alpha-2 code http://www.loc.gov/standards/iso639-2/ascii_8bits.html).
-  List<String> languages;
-
-  /// the list of addresses (with address type).
-  List<Address> addresses;
-
-  /// Mr., Ms., Pr., Dr. ...
-  ///
-  /// Please note: This property should have been non-nullable! Since the specification file
-  /// does not include a default value (using the "default:" property), however, the generated
-  /// source code must fall back to having a nullable type.
-  /// Consider adding a "default:" property in the specification file to hide this note.
-  ///
-  String? civility;
-
-  /// the gender of the patient: male, female, indeterminate, changed, changedToMale, changedToFemale, unknown
-  PatientGenderEnum? gender;
-
-  /// the birth sex of the patient: male, female, indeterminate, unknown
-  PatientBirthSexEnum? birthSex;
-
-  /// The id of the patient this patient has been merged with.
-  ///
-  /// Please note: This property should have been non-nullable! Since the specification file
-  /// does not include a default value (using the "default:" property), however, the generated
-  /// source code must fall back to having a nullable type.
-  /// Consider adding a "default:" property in the specification file to hide this note.
-  ///
-  String? mergeToPatientId;
-
-  /// The ids of the patients that have been merged inside this patient.
-  Set<String> mergedIds;
-
-  /// An alias of the person, nickname, ...
-  ///
-  /// Please note: This property should have been non-nullable! Since the specification file
-  /// does not include a default value (using the "default:" property), however, the generated
-  /// source code must fall back to having a nullable type.
-  /// Consider adding a "default:" property in the specification file to hide this note.
-  ///
-  String? alias;
-
-  /// Is the patient active (boolean).
-  bool active;
-
-  /// When not active, the reason for deactivation.
-  PatientDeactivationReasonEnum deactivationReason;
-
-  /// Social security inscription number.
-  ///
-  /// Please note: This property should have been non-nullable! Since the specification file
-  /// does not include a default value (using the "default:" property), however, the generated
-  /// source code must fall back to having a nullable type.
-  /// Consider adding a "default:" property in the specification file to hide this note.
-  ///
-  String? ssin;
-
-  /// Lastname at birth (can be different of the current name), depending on the country, must be used to design the patient .
-  ///
-  /// Please note: This property should have been non-nullable! Since the specification file
-  /// does not include a default value (using the "default:" property), however, the generated
-  /// source code must fall back to having a nullable type.
-  /// Consider adding a "default:" property in the specification file to hide this note.
-  ///
-  String? maidenName;
-
-  /// Lastname of the spouse for a married woman, depending on the country, can be used to design the patient.
-  ///
-  /// Please note: This property should have been non-nullable! Since the specification file
-  /// does not include a default value (using the "default:" property), however, the generated
-  /// source code must fall back to having a nullable type.
-  /// Consider adding a "default:" property in the specification file to hide this note.
-  ///
-  String? spouseName;
-
-  /// Lastname of the partner, should not be used to design the patient.
-  ///
-  /// Please note: This property should have been non-nullable! Since the specification file
-  /// does not include a default value (using the "default:" property), however, the generated
-  /// source code must fall back to having a nullable type.
-  /// Consider adding a "default:" property in the specification file to hide this note.
-  ///
-  String? partnerName;
-
-  /// any of `single`, `in_couple`, `married`, `separated`, `divorced`, `divorcing`, `widowed`, `widower`, `complicated`, `unknown`, `contract`, `other`.
-  PatientPersonalStatusEnum? personalStatus;
-
-  /// The birthdate encoded as a fuzzy date on 8 positions (YYYYMMDD) MM and/or DD can be set to 00 if unknown (19740000 is a valid date).
-  ///
-  /// Please note: This property should have been non-nullable! Since the specification file
-  /// does not include a default value (using the "default:" property), however, the generated
-  /// source code must fall back to having a nullable type.
-  /// Consider adding a "default:" property in the specification file to hide this note.
-  ///
-  int? dateOfBirth;
-
-  /// The date of death encoded as a fuzzy date on 8 positions (YYYYMMDD) MM and/or DD can be set to 00 if unknown (19740000 is a valid date).
-  ///
-  /// Please note: This property should have been non-nullable! Since the specification file
-  /// does not include a default value (using the "default:" property), however, the generated
-  /// source code must fall back to having a nullable type.
-  /// Consider adding a "default:" property in the specification file to hide this note.
-  ///
-  int? dateOfDeath;
-
-  /// The place of birth.
-  ///
-  /// Please note: This property should have been non-nullable! Since the specification file
-  /// does not include a default value (using the "default:" property), however, the generated
-  /// source code must fall back to having a nullable type.
-  /// Consider adding a "default:" property in the specification file to hide this note.
-  ///
-  String? placeOfBirth;
-
-  /// The place of death.
-  ///
-  /// Please note: This property should have been non-nullable! Since the specification file
-  /// does not include a default value (using the "default:" property), however, the generated
-  /// source code must fall back to having a nullable type.
-  /// Consider adding a "default:" property in the specification file to hide this note.
-  ///
-  String? placeOfDeath;
-
-  /// Is the patient deceased.
-  ///
-  /// Please note: This property should have been non-nullable! Since the specification file
-  /// does not include a default value (using the "default:" property), however, the generated
-  /// source code must fall back to having a nullable type.
-  /// Consider adding a "default:" property in the specification file to hide this note.
-  ///
-  bool? deceased;
-
-  /// The level of education (college degree, undergraduate, phd).
-  ///
-  /// Please note: This property should have been non-nullable! Since the specification file
-  /// does not include a default value (using the "default:" property), however, the generated
-  /// source code must fall back to having a nullable type.
-  /// Consider adding a "default:" property in the specification file to hide this note.
-  ///
-  String? education;
-
-  /// The current professional activity.
-  ///
-  /// Please note: This property should have been non-nullable! Since the specification file
-  /// does not include a default value (using the "default:" property), however, the generated
-  /// source code must fall back to having a nullable type.
-  /// Consider adding a "default:" property in the specification file to hide this note.
-  ///
-  String? profession;
-
-  /// A text note (can be confidential, encrypted by default).
-  ///
-  /// Please note: This property should have been non-nullable! Since the specification file
-  /// does not include a default value (using the "default:" property), however, the generated
-  /// source code must fall back to having a nullable type.
-  /// Consider adding a "default:" property in the specification file to hide this note.
-  ///
-  String? note;
-
-  /// An administrative note, not confidential.
-  ///
-  /// Please note: This property should have been non-nullable! Since the specification file
-  /// does not include a default value (using the "default:" property), however, the generated
-  /// source code must fall back to having a nullable type.
-  /// Consider adding a "default:" property in the specification file to hide this note.
-  ///
-  String? administrativeNote;
-
-  /// The nationality of the patient.
-  ///
-  /// Please note: This property should have been non-nullable! Since the specification file
-  /// does not include a default value (using the "default:" property), however, the generated
-  /// source code must fall back to having a nullable type.
-  /// Consider adding a "default:" property in the specification file to hide this note.
-  ///
-  String? nationality;
-
-  /// The race of the patient.
-  ///
-  /// Please note: This property should have been non-nullable! Since the specification file
-  /// does not include a default value (using the "default:" property), however, the generated
-  /// source code must fall back to having a nullable type.
-  /// Consider adding a "default:" property in the specification file to hide this note.
-  ///
-  String? race;
-
-  /// The ethnicity of the patient.
-  ///
-  /// Please note: This property should have been non-nullable! Since the specification file
-  /// does not include a default value (using the "default:" property), however, the generated
-  /// source code must fall back to having a nullable type.
-  /// Consider adding a "default:" property in the specification file to hide this note.
-  ///
-  String? ethnicity;
-
-  /// A picture usually saved in JPEG format.
-  ///
-  /// Please note: This property should have been non-nullable! Since the specification file
-  /// does not include a default value (using the "default:" property), however, the generated
-  /// source code must fall back to having a nullable type.
-  /// Consider adding a "default:" property in the specification file to hide this note.
-  ///
-  String? picture;
-
-  /// An external (from another source) id with no guarantee or requirement for unicity .
-  ///
-  /// Please note: This property should have been non-nullable! Since the specification file
-  /// does not include a default value (using the "default:" property), however, the generated
-  /// source code must fall back to having a nullable type.
-  /// Consider adding a "default:" property in the specification file to hide this note.
-  ///
-  String? externalId;
-
-  /// List of partners, or persons of contact (of class Partnership, see below).
-  List<Partnership> partnerships;
-
-  /// Links (usually for therapeutic reasons) between this patient and healthcare parties (of class PatientHealthcareParty).
-  List<PatientHealthCareParty> patientHealthCareParties;
-
-  /// Codified list of professions exercised by this patient.
-  List<CodingReference> patientProfessions;
-
-  /// Extra parameters
-  Map<String, List<String>> parameters;
-
-  /// Extra properties
-  Set<Property> properties;
-
-  ///
-  /// Please note: This property should have been non-nullable! Since the specification file
-  /// does not include a default value (using the "default:" property), however, the generated
-  /// source code must fall back to having a nullable type.
-  /// Consider adding a "default:" property in the specification file to hide this note.
-  ///
-  SystemMetaDataOwnerEncrypted? systemMetaData;
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is Patient &&
-          other.id == id &&
-          other.rev == rev &&
-          ListEquality().equals(other.identifiers, identifiers) &&
-          other.created == created &&
-          other.modified == modified &&
-          other.author == author &&
-          other.responsible == responsible &&
-          SetEquality().equals(other.labels, labels) &&
-          SetEquality().equals(other.codes, codes) &&
-          other.endOfLife == endOfLife &&
-          other.deletionDate == deletionDate &&
-          other.firstName == firstName &&
-          other.lastName == lastName &&
-          ListEquality().equals(other.names, names) &&
-          other.companyName == companyName &&
-          ListEquality().equals(other.languages, languages) &&
-          ListEquality().equals(other.addresses, addresses) &&
-          other.civility == civility &&
-          other.gender == gender &&
-          other.birthSex == birthSex &&
-          other.mergeToPatientId == mergeToPatientId &&
-          SetEquality().equals(other.mergedIds, mergedIds) &&
-          other.alias == alias &&
-          other.active == active &&
-          other.deactivationReason == deactivationReason &&
-          other.ssin == ssin &&
-          other.maidenName == maidenName &&
-          other.spouseName == spouseName &&
-          other.partnerName == partnerName &&
-          other.personalStatus == personalStatus &&
-          other.dateOfBirth == dateOfBirth &&
-          other.dateOfDeath == dateOfDeath &&
-          other.placeOfBirth == placeOfBirth &&
-          other.placeOfDeath == placeOfDeath &&
-          other.deceased == deceased &&
-          other.education == education &&
-          other.profession == profession &&
-          other.note == note &&
-          other.administrativeNote == administrativeNote &&
-          other.nationality == nationality &&
-          other.race == race &&
-          other.ethnicity == ethnicity &&
-          other.picture == picture &&
-          other.externalId == externalId &&
-          ListEquality().equals(other.partnerships, partnerships) &&
-          ListEquality().equals(other.patientHealthCareParties, patientHealthCareParties) &&
-          ListEquality().equals(other.patientProfessions, patientProfessions) &&
-          MapEquality(values: ListEquality()).equals(other.parameters, parameters) &&
-          SetEquality().equals(other.properties, properties) &&
-          other.systemMetaData == systemMetaData;
-
-  @override
-  int get hashCode =>
-      // ignore: unnecessary_parenthesis
-      (id == null ? 0 : id!.hashCode) +
-      (rev == null ? 0 : rev!.hashCode) +
-      (identifiers.hashCode) +
-      (created == null ? 0 : created!.hashCode) +
-      (modified == null ? 0 : modified!.hashCode) +
-      (author == null ? 0 : author!.hashCode) +
-      (responsible == null ? 0 : responsible!.hashCode) +
-      (labels.hashCode) +
-      (codes.hashCode) +
-      (endOfLife == null ? 0 : endOfLife!.hashCode) +
-      (deletionDate == null ? 0 : deletionDate!.hashCode) +
-      (firstName == null ? 0 : firstName!.hashCode) +
-      (lastName == null ? 0 : lastName!.hashCode) +
-      (names.hashCode) +
-      (companyName == null ? 0 : companyName!.hashCode) +
-      (languages.hashCode) +
-      (addresses.hashCode) +
-      (civility == null ? 0 : civility!.hashCode) +
-      (gender == null ? 0 : gender!.hashCode) +
-      (birthSex == null ? 0 : birthSex!.hashCode) +
-      (mergeToPatientId == null ? 0 : mergeToPatientId!.hashCode) +
-      (mergedIds.hashCode) +
-      (alias == null ? 0 : alias!.hashCode) +
-      (active.hashCode) +
-      (deactivationReason.hashCode) +
-      (ssin == null ? 0 : ssin!.hashCode) +
-      (maidenName == null ? 0 : maidenName!.hashCode) +
-      (spouseName == null ? 0 : spouseName!.hashCode) +
-      (partnerName == null ? 0 : partnerName!.hashCode) +
-      (personalStatus == null ? 0 : personalStatus!.hashCode) +
-      (dateOfBirth == null ? 0 : dateOfBirth!.hashCode) +
-      (dateOfDeath == null ? 0 : dateOfDeath!.hashCode) +
-      (placeOfBirth == null ? 0 : placeOfBirth!.hashCode) +
-      (placeOfDeath == null ? 0 : placeOfDeath!.hashCode) +
-      (deceased == null ? 0 : deceased!.hashCode) +
-      (education == null ? 0 : education!.hashCode) +
-      (profession == null ? 0 : profession!.hashCode) +
-      (note == null ? 0 : note!.hashCode) +
-      (administrativeNote == null ? 0 : administrativeNote!.hashCode) +
-      (nationality == null ? 0 : nationality!.hashCode) +
-      (race == null ? 0 : race!.hashCode) +
-      (ethnicity == null ? 0 : ethnicity!.hashCode) +
-      (picture == null ? 0 : picture!.hashCode) +
-      (externalId == null ? 0 : externalId!.hashCode) +
-      (partnerships.hashCode) +
-      (patientHealthCareParties.hashCode) +
-      (patientProfessions.hashCode) +
-      (parameters.hashCode) +
-      (properties.hashCode) +
-      (systemMetaData == null ? 0 : systemMetaData!.hashCode);
-
-  @override
-  String toString() =>
-      'Patient[id=$id, rev=$rev, identifiers=$identifiers, created=$created, modified=$modified, author=$author, responsible=$responsible, labels=$labels, codes=$codes, endOfLife=$endOfLife, deletionDate=$deletionDate, firstName=$firstName, lastName=$lastName, names=$names, companyName=$companyName, languages=$languages, addresses=$addresses, civility=$civility, gender=$gender, birthSex=$birthSex, mergeToPatientId=$mergeToPatientId, mergedIds=$mergedIds, alias=$alias, active=$active, deactivationReason=$deactivationReason, ssin=$ssin, maidenName=$maidenName, spouseName=$spouseName, partnerName=$partnerName, personalStatus=$personalStatus, dateOfBirth=$dateOfBirth, dateOfDeath=$dateOfDeath, placeOfBirth=$placeOfBirth, placeOfDeath=$placeOfDeath, deceased=$deceased, education=$education, profession=$profession, note=$note, administrativeNote=$administrativeNote, nationality=$nationality, race=$race, ethnicity=$ethnicity, picture=$picture, externalId=$externalId, partnerships=$partnerships, patientHealthCareParties=$patientHealthCareParties, patientProfessions=$patientProfessions, parameters=$parameters, properties=$properties, systemMetaData=$systemMetaData]';
-
-  Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
-    if (id != null) {
-      json[r'id'] = id;
-    }
-    if (rev != null) {
-      json[r'rev'] = rev;
-    }
-    json[r'identifiers'] = identifiers;
-    if (created != null) {
-      json[r'created'] = created;
-    }
-    if (modified != null) {
-      json[r'modified'] = modified;
-    }
-    if (author != null) {
-      json[r'author'] = author;
-    }
-    if (responsible != null) {
-      json[r'responsible'] = responsible;
-    }
-    json[r'labels'] = labels.toList();
-    json[r'codes'] = codes.toList();
-    if (endOfLife != null) {
-      json[r'endOfLife'] = endOfLife;
-    }
-    if (deletionDate != null) {
-      json[r'deletionDate'] = deletionDate;
-    }
-    if (firstName != null) {
-      json[r'firstName'] = firstName;
-    }
-    if (lastName != null) {
-      json[r'lastName'] = lastName;
-    }
-    json[r'names'] = names;
-    if (companyName != null) {
-      json[r'companyName'] = companyName;
-    }
-    json[r'languages'] = languages;
-    json[r'addresses'] = addresses;
-    if (civility != null) {
-      json[r'civility'] = civility;
-    }
-    if (gender != null) {
-      json[r'gender'] = gender;
-    }
-    if (birthSex != null) {
-      json[r'birthSex'] = birthSex;
-    }
-    if (mergeToPatientId != null) {
-      json[r'mergeToPatientId'] = mergeToPatientId;
-    }
-    json[r'mergedIds'] = mergedIds.toList();
-    if (alias != null) {
-      json[r'alias'] = alias;
-    }
-    json[r'active'] = active;
-    json[r'deactivationReason'] = deactivationReason;
-    if (ssin != null) {
-      json[r'ssin'] = ssin;
-    }
-    if (maidenName != null) {
-      json[r'maidenName'] = maidenName;
-    }
-    if (spouseName != null) {
-      json[r'spouseName'] = spouseName;
-    }
-    if (partnerName != null) {
-      json[r'partnerName'] = partnerName;
-    }
-    if (personalStatus != null) {
-      json[r'personalStatus'] = personalStatus;
-    }
-    if (dateOfBirth != null) {
-      json[r'dateOfBirth'] = dateOfBirth;
-    }
-    if (dateOfDeath != null) {
-      json[r'dateOfDeath'] = dateOfDeath;
-    }
-    if (placeOfBirth != null) {
-      json[r'placeOfBirth'] = placeOfBirth;
-    }
-    if (placeOfDeath != null) {
-      json[r'placeOfDeath'] = placeOfDeath;
-    }
-    if (deceased != null) {
-      json[r'deceased'] = deceased;
-    }
-    if (education != null) {
-      json[r'education'] = education;
-    }
-    if (profession != null) {
-      json[r'profession'] = profession;
-    }
-    if (note != null) {
-      json[r'note'] = note;
-    }
-    if (administrativeNote != null) {
-      json[r'administrativeNote'] = administrativeNote;
-    }
-    if (nationality != null) {
-      json[r'nationality'] = nationality;
-    }
-    if (race != null) {
-      json[r'race'] = race;
-    }
-    if (ethnicity != null) {
-      json[r'ethnicity'] = ethnicity;
-    }
-    if (picture != null) {
-      json[r'picture'] = picture;
-    }
-    if (externalId != null) {
-      json[r'externalId'] = externalId;
-    }
-    json[r'partnerships'] = partnerships;
-    json[r'patientHealthCareParties'] = patientHealthCareParties;
-    json[r'patientProfessions'] = patientProfessions;
-    json[r'parameters'] = parameters;
-    json[r'properties'] = properties.toList();
-    if (systemMetaData != null) {
-      json[r'systemMetaData'] = systemMetaData;
-    }
-    return json;
-  }
-
   /// Returns a new [Patient] instance and imports its values from
   /// [value] if it's a [Map], null otherwise.
   // ignore: prefer_constructors_over_static_methods
@@ -696,8 +109,8 @@ class Patient {
         mergedIds: json[r'mergedIds'] is Set
             ? (json[r'mergedIds'] as Set).cast<String>()
             : json[r'mergedIds'] is List
-                ? ((json[r'mergedIds'] as List).toSet()).cast<String>()
-                : const {},
+            ? ((json[r'mergedIds'] as List).toSet()).cast<String>()
+            : const {},
         alias: mapValueOfType<String>(json, r'alias'),
         active: mapValueOfType<bool>(json, r'active')!,
         deactivationReason: PatientDeactivationReasonEnum.fromJson(json[r'deactivationReason'])!,
@@ -732,9 +145,9 @@ class Patient {
   }
 
   static List<Patient>? listFromJson(
-    dynamic json, {
-    bool growable = false,
-  }) {
+      dynamic json, {
+        bool growable = false,
+      }) {
     final result = <Patient>[];
     if (json is List && json.isNotEmpty) {
       for (final row in json) {
@@ -763,9 +176,9 @@ class Patient {
 
   // maps a json object with a list of Patient-objects as value to a dart map
   static Map<String, List<Patient>> mapListFromJson(
-    dynamic json, {
-    bool growable = false,
-  }) {
+      dynamic json, {
+        bool growable = false,
+      }) {
     final map = <String, List<Patient>>{};
     if (json is Map && json.isNotEmpty) {
       json = json.cast<String, dynamic>(); // ignore: parameter_assignments
@@ -799,7 +212,973 @@ class Patient {
     'parameters',
     'properties',
   };
+
+  @override
+  SystemMetaDataOwnerEncrypted? systemMetaData;
+
+  @override
+  bool active;
+
+  @override
+  List<Address> addresses;
+
+  @override
+  String? administrativeNote;
+
+  @override
+  String? alias;
+
+  @override
+  String? author;
+
+  @override
+  PatientBirthSexEnum? birthSex;
+
+  @override
+  String? civility;
+
+  @override
+  Set<CodingReference> codes;
+
+  @override
+  String? companyName;
+
+  @override
+  int? created;
+
+  @override
+  int? dateOfBirth;
+
+  @override
+  int? dateOfDeath;
+
+  @override
+  PatientDeactivationReasonEnum deactivationReason;
+
+  @override
+  bool? deceased;
+
+  @override
+  int? deletionDate;
+
+  @override
+  String? education;
+
+  @override
+  int? endOfLife;
+
+  @override
+  String? ethnicity;
+
+  @override
+  String? externalId;
+
+  @override
+  String? firstName;
+
+  @override
+  PatientGenderEnum? gender;
+
+  @override
+  String? id;
+
+  @override
+  List<Identifier> identifiers;
+
+  @override
+  Set<CodingReference> labels;
+
+  @override
+  List<String> languages;
+
+  @override
+  String? lastName;
+
+  @override
+  String? maidenName;
+
+  @override
+  String? mergeToPatientId;
+
+  @override
+  Set<String> mergedIds;
+
+  @override
+  int? modified;
+
+  @override
+  List<PersonName> names;
+
+  @override
+  String? nationality;
+
+  @override
+  String? note;
+
+  @override
+  Map<String, List<String>> parameters;
+
+  @override
+  String? partnerName;
+
+  @override
+  List<Partnership> partnerships;
+
+  @override
+  List<PatientHealthCareParty> patientHealthCareParties;
+
+  @override
+  List<CodingReference> patientProfessions;
+
+  @override
+  PatientPersonalStatusEnum? personalStatus;
+
+  @override
+  String? picture;
+
+  @override
+  String? placeOfBirth;
+
+  @override
+  String? placeOfDeath;
+
+  @override
+  String? profession;
+
+  @override
+  Set<Property> properties;
+
+  @override
+  String? race;
+
+  @override
+  String? responsible;
+
+  @override
+  String? rev;
+
+  @override
+  String? spouseName;
+
+  @override
+  String? ssin;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || (other is Patient && __potentiallyEncryptedPatientEquality(this, other));
+
+  @override
+  int get hashCode => __potentiallyEncryptedPatientHashCode(this);
+
+  @override
+  String toString() => 'Patient[${__potentiallyEncryptedPatientFieldsString(this)}]';
+
+  Map<String, dynamic> toJson() => __potentiallyEncryptedPatientToJson(this);
 }
+
+class EncryptedPatient implements PotentiallyEncryptedPatient {
+
+  /// Returns a new [EncryptedPatient] instance.
+  EncryptedPatient({
+    this.id,
+    this.rev,
+    this.identifiers = const [],
+    this.created,
+    this.modified,
+    this.author,
+    this.responsible,
+    this.labels = const {},
+    this.codes = const {},
+    this.endOfLife,
+    this.deletionDate,
+    this.firstName,
+    this.lastName,
+    this.names = const [],
+    this.companyName,
+    this.languages = const [],
+    this.addresses = const [],
+    this.civility,
+    this.gender,
+    this.birthSex,
+    this.mergeToPatientId,
+    this.mergedIds = const {},
+    this.alias,
+    this.active = true,
+    this.deactivationReason = const PatientDeactivationReasonEnum._('DeactivationReason.none'),
+    this.ssin,
+    this.maidenName,
+    this.spouseName,
+    this.partnerName,
+    this.personalStatus,
+    this.dateOfBirth,
+    this.dateOfDeath,
+    this.placeOfBirth,
+    this.placeOfDeath,
+    this.deceased,
+    this.education,
+    this.profession,
+    this.note,
+    this.administrativeNote,
+    this.nationality,
+    this.race,
+    this.ethnicity,
+    this.picture,
+    this.externalId,
+    this.partnerships = const [],
+    this.patientHealthCareParties = const [],
+    this.patientProfessions = const [],
+    this.parameters = const {},
+    this.properties = const {},
+    this.systemMetaData,
+  });
+
+  @override
+  SystemMetaDataOwnerEncrypted? systemMetaData;
+
+  @override
+  bool active;
+
+  @override
+  List<Address> addresses;
+
+  @override
+  String? administrativeNote;
+
+  @override
+  String? alias;
+
+  @override
+  String? author;
+
+  @override
+  PatientBirthSexEnum? birthSex;
+
+  @override
+  String? civility;
+
+  @override
+  Set<CodingReference> codes;
+
+  @override
+  String? companyName;
+
+  @override
+  int? created;
+
+  @override
+  int? dateOfBirth;
+
+  @override
+  int? dateOfDeath;
+
+  @override
+  PatientDeactivationReasonEnum deactivationReason;
+
+  @override
+  bool? deceased;
+
+  @override
+  int? deletionDate;
+
+  @override
+  String? education;
+
+  @override
+  int? endOfLife;
+
+  @override
+  String? ethnicity;
+
+  @override
+  String? externalId;
+
+  @override
+  String? firstName;
+
+  @override
+  PatientGenderEnum? gender;
+
+  @override
+  String? id;
+
+  @override
+  List<Identifier> identifiers;
+
+  @override
+  Set<CodingReference> labels;
+
+  @override
+  List<String> languages;
+
+  @override
+  String? lastName;
+
+  @override
+  String? maidenName;
+
+  @override
+  String? mergeToPatientId;
+
+  @override
+  Set<String> mergedIds;
+
+  @override
+  int? modified;
+
+  @override
+  List<PersonName> names;
+
+  @override
+  String? nationality;
+
+  @override
+  String? note;
+
+  @override
+  Map<String, List<String>> parameters;
+
+  @override
+  String? partnerName;
+
+  @override
+  List<Partnership> partnerships;
+
+  @override
+  List<PatientHealthCareParty> patientHealthCareParties;
+
+  @override
+  List<CodingReference> patientProfessions;
+
+  @override
+  PatientPersonalStatusEnum? personalStatus;
+
+  @override
+  String? picture;
+
+  @override
+  String? placeOfBirth;
+
+  @override
+  String? placeOfDeath;
+
+  @override
+  String? profession;
+
+  @override
+  Set<Property> properties;
+
+  @override
+  String? race;
+
+  @override
+  String? responsible;
+
+  @override
+  String? rev;
+
+  @override
+  String? spouseName;
+
+  @override
+  String? ssin;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || (other is EncryptedPatient && __potentiallyEncryptedPatientEquality(this, other));
+
+  @override
+  int get hashCode => __potentiallyEncryptedPatientHashCode(this);
+
+  @override
+  String toString() => 'EncryptedPatient[${__potentiallyEncryptedPatientFieldsString(this)}]';
+
+  Map<String, dynamic> toJson() => __potentiallyEncryptedPatientToJson(this);
+}
+
+abstract class PotentiallyEncryptedPatient {
+  /// the Id of the patient. We encourage using either a v4 UUID or a HL7 Id.
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  String? get id;
+
+  /// the revision of the patient in the database, used for conflict management / optimistic locking.
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  String? get rev;
+
+  /// Typically used for business / client identifiers. An identifier should identify a patient uniquely and unambiguously. However, iCure can't guarantee the uniqueness of those identifiers : This is something you need to take care of.
+  List<Identifier> get identifiers;
+
+  /// the creation date of the patient (encoded as epoch).
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  int? get created;
+
+  /// the last modification date of the patient (encoded as epoch).
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  int? get modified;
+
+  /// The id of the [User] that created this patient. When creating the patient, this field will be filled automatically by the current user id if not provided.
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  String? get author;
+
+  /// The id of the data owner that is responsible of this patient. When creating the patient, will be filled automatically by the current user data owner id ([HealthcareProfessional], [Patient] or [MedicalDevice]) if missing
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  String? get responsible;
+
+  /// A label is an item from a codification system that qualifies a patient as being member of a certain class, whatever the value it might have taken. If the label qualifies the content of a field, it means that whatever the content of the field, the label will always apply. LOINC is a codification system typically used for labels.
+  Set<CodingReference> get labels;
+
+  /// A code is an item from a codification system that qualifies the content of this patient.
+  Set<CodingReference> get codes;
+
+  /// Soft delete (unix epoch in ms) timestamp of the patient
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  int? get endOfLife;
+
+  /// the soft delete timestamp. When a patient is ”deleted“, this is set to a non null value: the moment of the deletion
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  int? get deletionDate;
+
+  /// the firstname (name) of the patient.
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  String? get firstName;
+
+  /// the lastname (surname) of the patient. This is the official lastname that should be used for official administrative purposes.
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  String? get lastName;
+
+  /// the list of all names of the patient, also containing the official full name information. Ordered by preference of use. First element is therefore the official name used for the patient in the application
+  List<PersonName> get names;
+
+  /// the name of the company this patient is member of.
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  String? get companyName;
+
+  /// the list of languages spoken by the patient ordered by fluency (alpha-2 code http://www.loc.gov/standards/iso639-2/ascii_8bits.html).
+  List<String> get languages;
+
+  /// the list of addresses (with address type).
+  List<Address> get addresses;
+
+  /// Mr., Ms., Pr., Dr. ...
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  String? get civility;
+
+  /// the gender of the patient: male, female, indeterminate, changed, changedToMale, changedToFemale, unknown
+  PatientGenderEnum? get gender;
+
+  /// the birth sex of the patient: male, female, indeterminate, unknown
+  PatientBirthSexEnum? get birthSex;
+
+  /// The id of the patient this patient has been merged with.
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  String? get mergeToPatientId;
+
+  /// The ids of the patients that have been merged inside this patient.
+  Set<String> get mergedIds;
+
+  /// An alias of the person, nickname, ...
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  String? get alias;
+
+  /// Is the patient active (boolean).
+  bool get active;
+
+  /// When not active, the reason for deactivation.
+  PatientDeactivationReasonEnum get deactivationReason;
+
+  /// Social security inscription number.
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  String? get ssin;
+
+  /// Lastname at birth (can be different of the current name), depending on the country, must be used to design the patient .
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  String? get maidenName;
+
+  /// Lastname of the spouse for a married woman, depending on the country, can be used to design the patient.
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  String? get spouseName;
+
+  /// Lastname of the partner, should not be used to design the patient.
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  String? get partnerName;
+
+  /// any of `single`, `in_couple`, `married`, `separated`, `divorced`, `divorcing`, `widowed`, `widower`, `complicated`, `unknown`, `contract`, `other`.
+  PatientPersonalStatusEnum? get personalStatus;
+
+  /// The birthdate encoded as a fuzzy date on 8 positions (YYYYMMDD) MM and/or DD can be set to 00 if unknown (19740000 is a valid date).
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  int? get dateOfBirth;
+
+  /// The date of death encoded as a fuzzy date on 8 positions (YYYYMMDD) MM and/or DD can be set to 00 if unknown (19740000 is a valid date).
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  int? get dateOfDeath;
+
+  /// The place of birth.
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  String? get placeOfBirth;
+
+  /// The place of death.
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  String? get placeOfDeath;
+
+  /// Is the patient deceased.
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  bool? get deceased;
+
+  /// The level of education (college degree, undergraduate, phd).
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  String? get education;
+
+  /// The current professional activity.
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  String? get profession;
+
+  /// A text note (can be confidential, encrypted by default).
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  String? get note;
+
+  /// An administrative note, not confidential.
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  String? get administrativeNote;
+
+  /// The nationality of the patient.
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  String? get nationality;
+
+  /// The race of the patient.
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  String? get race;
+
+  /// The ethnicity of the patient.
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  String? get ethnicity;
+
+  /// A picture usually saved in JPEG format.
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  String? get picture;
+
+  /// An external (from another source) id with no guarantee or requirement for unicity .
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  String? get externalId;
+
+  /// List of partners, or persons of contact (of class Partnership, see below).
+  List<Partnership> get partnerships;
+
+  /// Links (usually for therapeutic reasons) between this patient and healthcare parties (of class PatientHealthcareParty).
+  List<PatientHealthCareParty> get patientHealthCareParties;
+
+  /// Codified list of professions exercised by this patient.
+  List<CodingReference> get patientProfessions;
+
+  /// Extra parameters
+  Map<String, List<String>> get parameters;
+
+  /// Extra properties
+  Set<Property> get properties;
+
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  SystemMetaDataOwnerEncrypted? systemMetaData;
+
+}
+
+bool __potentiallyEncryptedPatientEquality(PotentiallyEncryptedPatient self, PotentiallyEncryptedPatient other) =>
+  other.id == self.id &&
+    other.rev == self.rev &&
+    ListEquality().equals(other.identifiers, self.identifiers) &&
+    other.created == self.created &&
+    other.modified == self.modified &&
+    other.author == self.author &&
+    other.responsible == self.responsible &&
+    SetEquality().equals(other.labels, self.labels) &&
+    SetEquality().equals(other.codes, self.codes) &&
+    other.endOfLife == self.endOfLife &&
+    other.deletionDate == self.deletionDate &&
+    other.firstName == self.firstName &&
+    other.lastName == self.lastName &&
+    ListEquality().equals(other.names, self.names) &&
+    other.companyName == self.companyName &&
+    ListEquality().equals(other.languages, self.languages) &&
+    ListEquality().equals(other.addresses, self.addresses) &&
+    other.civility == self.civility &&
+    other.gender == self.gender &&
+    other.birthSex == self.birthSex &&
+    other.mergeToPatientId == self.mergeToPatientId &&
+    SetEquality().equals(other.mergedIds, self.mergedIds) &&
+    other.alias == self.alias &&
+    other.active == self.active &&
+    other.deactivationReason == self.deactivationReason &&
+    other.ssin == self.ssin &&
+    other.maidenName == self.maidenName &&
+    other.spouseName == self.spouseName &&
+    other.partnerName == self.partnerName &&
+    other.personalStatus == self.personalStatus &&
+    other.dateOfBirth == self.dateOfBirth &&
+    other.dateOfDeath == self.dateOfDeath &&
+    other.placeOfBirth == self.placeOfBirth &&
+    other.placeOfDeath == self.placeOfDeath &&
+    other.deceased == self.deceased &&
+    other.education == self.education &&
+    other.profession == self.profession &&
+    other.note == self.note &&
+    other.administrativeNote == self.administrativeNote &&
+    other.nationality == self.nationality &&
+    other.race == self.race &&
+    other.ethnicity == self.ethnicity &&
+    other.picture == self.picture &&
+    other.externalId == self.externalId &&
+    ListEquality().equals(other.partnerships, self.partnerships) &&
+    ListEquality().equals(other.patientHealthCareParties, self.patientHealthCareParties) &&
+    ListEquality().equals(other.patientProfessions, self.patientProfessions) &&
+    MapEquality(values: ListEquality()).equals(other.parameters, self.parameters) &&
+    SetEquality().equals(other.properties, self.properties) &&
+    other.systemMetaData == self.systemMetaData;
+
+int __potentiallyEncryptedPatientHashCode(PotentiallyEncryptedPatient self) =>
+  // ignore: unnecessary_parenthesis
+  (self.id == null ? 0 : self.id!.hashCode) +
+  (self.rev == null ? 0 : self.rev!.hashCode) +
+  (self.identifiers.hashCode) +
+  (self.created == null ? 0 : self.created!.hashCode) +
+  (self.modified == null ? 0 : self.modified!.hashCode) +
+  (self.author == null ? 0 : self.author!.hashCode) +
+  (self.responsible == null ? 0 : self.responsible!.hashCode) +
+  (self.labels.hashCode) +
+  (self.codes.hashCode) +
+  (self.endOfLife == null ? 0 : self.endOfLife!.hashCode) +
+  (self.deletionDate == null ? 0 : self.deletionDate!.hashCode) +
+  (self.firstName == null ? 0 : self.firstName!.hashCode) +
+  (self.lastName == null ? 0 : self.lastName!.hashCode) +
+  (self.names.hashCode) +
+  (self.companyName == null ? 0 : self.companyName!.hashCode) +
+  (self.languages.hashCode) +
+  (self.addresses.hashCode) +
+  (self.civility == null ? 0 : self.civility!.hashCode) +
+  (self.gender == null ? 0 : self.gender!.hashCode) +
+  (self.birthSex == null ? 0 : self.birthSex!.hashCode) +
+  (self.mergeToPatientId == null ? 0 : self.mergeToPatientId!.hashCode) +
+  (self.mergedIds.hashCode) +
+  (self.alias == null ? 0 : self.alias!.hashCode) +
+  (self.active.hashCode) +
+  (self.deactivationReason.hashCode) +
+  (self.ssin == null ? 0 : self.ssin!.hashCode) +
+  (self.maidenName == null ? 0 : self.maidenName!.hashCode) +
+  (self.spouseName == null ? 0 : self.spouseName!.hashCode) +
+  (self.partnerName == null ? 0 : self.partnerName!.hashCode) +
+  (self.personalStatus == null ? 0 : self.personalStatus!.hashCode) +
+  (self.dateOfBirth == null ? 0 : self.dateOfBirth!.hashCode) +
+  (self.dateOfDeath == null ? 0 : self.dateOfDeath!.hashCode) +
+  (self.placeOfBirth == null ? 0 : self.placeOfBirth!.hashCode) +
+  (self.placeOfDeath == null ? 0 : self.placeOfDeath!.hashCode) +
+  (self.deceased == null ? 0 : self.deceased!.hashCode) +
+  (self.education == null ? 0 : self.education!.hashCode) +
+  (self.profession == null ? 0 : self.profession!.hashCode) +
+  (self.note == null ? 0 : self.note!.hashCode) +
+  (self.administrativeNote == null ? 0 : self.administrativeNote!.hashCode) +
+  (self.nationality == null ? 0 : self.nationality!.hashCode) +
+  (self.race == null ? 0 : self.race!.hashCode) +
+  (self.ethnicity == null ? 0 : self.ethnicity!.hashCode) +
+  (self.picture == null ? 0 : self.picture!.hashCode) +
+  (self.externalId == null ? 0 : self.externalId!.hashCode) +
+  (self.partnerships.hashCode) +
+  (self.patientHealthCareParties.hashCode) +
+  (self.patientProfessions.hashCode) +
+  (self.parameters.hashCode) +
+  (self.properties.hashCode) +
+  (self.systemMetaData == null ? 0 : self.systemMetaData!.hashCode);
+
+String __potentiallyEncryptedPatientFieldsString(PotentiallyEncryptedPatient self) =>
+  'id=${self.id}, rev=${self.rev}, identifiers=${self.identifiers}, created=${self.created}, modified=${self.modified}, author=${self.author}, responsible=${self.responsible}, labels=${self.labels}, codes=${self.codes}, endOfLife=${self.endOfLife}, deletionDate=${self.deletionDate}, firstName=${self.firstName}, lastName=${self.lastName}, names=${self.names}, companyName=${self.companyName}, languages=${self.languages}, addresses=${self.addresses}, civility=${self.civility}, gender=${self.gender}, birthSex=${self.birthSex}, mergeToPatientId=${self.mergeToPatientId}, mergedIds=${self.mergedIds}, alias=${self.alias}, active=${self.active}, deactivationReason=${self.deactivationReason}, ssin=${self.ssin}, maidenName=${self.maidenName}, spouseName=${self.spouseName}, partnerName=${self.partnerName}, personalStatus=${self.personalStatus}, dateOfBirth=${self.dateOfBirth}, dateOfDeath=${self.dateOfDeath}, placeOfBirth=${self.placeOfBirth}, placeOfDeath=${self.placeOfDeath}, deceased=${self.deceased}, education=${self.education}, profession=${self.profession}, note=${self.note}, administrativeNote=${self.administrativeNote}, nationality=${self.nationality}, race=${self.race}, ethnicity=${self.ethnicity}, picture=${self.picture}, externalId=${self.externalId}, partnerships=${self.partnerships}, patientHealthCareParties=${self.patientHealthCareParties}, patientProfessions=${self.patientProfessions}, parameters=${self.parameters}, properties=${self.properties}, systemMetaData=${self.systemMetaData}';
+
+Map<String, dynamic> __potentiallyEncryptedPatientToJson(PotentiallyEncryptedPatient self) {
+    final json = <String, dynamic>{};
+    if (self.id != null) {
+      json[r'id'] = self.id;
+    }
+    if (self.rev != null) {
+      json[r'rev'] = self.rev;
+    }
+    json[r'identifiers'] = self.identifiers;
+    if (self.created != null) {
+      json[r'created'] = self.created;
+    }
+    if (self.modified != null) {
+      json[r'modified'] = self.modified;
+    }
+    if (self.author != null) {
+      json[r'author'] = self.author;
+    }
+    if (self.responsible != null) {
+      json[r'responsible'] = self.responsible;
+    }
+    json[r'labels'] = self.labels.toList();
+    json[r'codes'] = self.codes.toList();
+    if (self.endOfLife != null) {
+      json[r'endOfLife'] = self.endOfLife;
+    }
+    if (self.deletionDate != null) {
+      json[r'deletionDate'] = self.deletionDate;
+    }
+    if (self.firstName != null) {
+      json[r'firstName'] = self.firstName;
+    }
+    if (self.lastName != null) {
+      json[r'lastName'] = self.lastName;
+    }
+    json[r'names'] = self.names;
+    if (self.companyName != null) {
+      json[r'companyName'] = self.companyName;
+    }
+    json[r'languages'] = self.languages;
+    json[r'addresses'] = self.addresses;
+    if (self.civility != null) {
+      json[r'civility'] = self.civility;
+    }
+    if (self.gender != null) {
+      json[r'gender'] = self.gender;
+    }
+    if (self.birthSex != null) {
+      json[r'birthSex'] = self.birthSex;
+    }
+    if (self.mergeToPatientId != null) {
+      json[r'mergeToPatientId'] = self.mergeToPatientId;
+    }
+    json[r'mergedIds'] = self.mergedIds.toList();
+    if (self.alias != null) {
+      json[r'alias'] = self.alias;
+    }
+    json[r'active'] = self.active;
+    json[r'deactivationReason'] = self.deactivationReason;
+    if (self.ssin != null) {
+      json[r'ssin'] = self.ssin;
+    }
+    if (self.maidenName != null) {
+      json[r'maidenName'] = self.maidenName;
+    }
+    if (self.spouseName != null) {
+      json[r'spouseName'] = self.spouseName;
+    }
+    if (self.partnerName != null) {
+      json[r'partnerName'] = self.partnerName;
+    }
+    if (self.personalStatus != null) {
+      json[r'personalStatus'] = self.personalStatus;
+    }
+    if (self.dateOfBirth != null) {
+      json[r'dateOfBirth'] = self.dateOfBirth;
+    }
+    if (self.dateOfDeath != null) {
+      json[r'dateOfDeath'] = self.dateOfDeath;
+    }
+    if (self.placeOfBirth != null) {
+      json[r'placeOfBirth'] = self.placeOfBirth;
+    }
+    if (self.placeOfDeath != null) {
+      json[r'placeOfDeath'] = self.placeOfDeath;
+    }
+    if (self.deceased != null) {
+      json[r'deceased'] = self.deceased;
+    }
+    if (self.education != null) {
+      json[r'education'] = self.education;
+    }
+    if (self.profession != null) {
+      json[r'profession'] = self.profession;
+    }
+    if (self.note != null) {
+      json[r'note'] = self.note;
+    }
+    if (self.administrativeNote != null) {
+      json[r'administrativeNote'] = self.administrativeNote;
+    }
+    if (self.nationality != null) {
+      json[r'nationality'] = self.nationality;
+    }
+    if (self.race != null) {
+      json[r'race'] = self.race;
+    }
+    if (self.ethnicity != null) {
+      json[r'ethnicity'] = self.ethnicity;
+    }
+    if (self.picture != null) {
+      json[r'picture'] = self.picture;
+    }
+    if (self.externalId != null) {
+      json[r'externalId'] = self.externalId;
+    }
+    json[r'partnerships'] = self.partnerships;
+    json[r'patientHealthCareParties'] = self.patientHealthCareParties;
+    json[r'patientProfessions'] = self.patientProfessions;
+    json[r'parameters'] = self.parameters;
+    json[r'properties'] = self.properties.toList();
+    if (self.systemMetaData != null) {
+      json[r'systemMetaData'] = self.systemMetaData;
+    }
+    return json;
+  }
 
 /// the gender of the patient: male, female, indeterminate, changed, changedToMale, changedToFemale, unknown
 class PatientGenderEnum {

--- a/lib/model/system_meta_data_owner.dart
+++ b/lib/model/system_meta_data_owner.dart
@@ -27,7 +27,7 @@ class SystemMetaDataOwner {
 
   Map<String, String> privateKeyShamirPartitions;
 
-  Map<String, Map<String, List<String>>> aesExchangeKeys;
+  Map<String, Map<String, Map<String, String>>> aesExchangeKeys;
 
   Map<String, Map<String, String>> transferKeys;
 
@@ -40,7 +40,7 @@ class SystemMetaDataOwner {
           other.publicKey == publicKey &&
           MapEquality(values: ListEquality()).equals(other.hcPartyKeys, hcPartyKeys) &&
           MapEquality().equals(other.privateKeyShamirPartitions, privateKeyShamirPartitions) &&
-          MapEquality(values: MapEquality(values: ListEquality())).equals(other.aesExchangeKeys, aesExchangeKeys) &&
+          MapEquality(values: MapEquality(values: MapEquality())).equals(other.aesExchangeKeys, aesExchangeKeys) &&
           MapEquality(values: MapEquality()).equals(other.transferKeys, transferKeys) &&
           ListEquality().equals(other.lostHcPartyKeys, lostHcPartyKeys);
 
@@ -93,7 +93,7 @@ class SystemMetaDataOwner {
         hcPartyKeys: json[r'hcPartyKeys'] == null ? const {} : mapWithListOfStringsFromJson(json[r'hcPartyKeys']),
         privateKeyShamirPartitions: mapCastOfType<String, String>(json, r'privateKeyShamirPartitions')!,
         lostHcPartyKeys: json[r'lostHcPartyKeys'] == null ? const [] : (json[r'lostHcPartyKeys'] as List).cast<String>(),
-        aesExchangeKeys: json[r'aesExchangeKeys'] == null ? const {} : mapOf(json[r'aesExchangeKeys'], (el) => mapWithListOfStringsFromJson(el)),
+        aesExchangeKeys: json[r'aesExchangeKeys'] == null ? const {} : mapOf(json[r'aesExchangeKeys'], (el) => mapWithMapOfStringsFromJson(el)),
         transferKeys: json[r'transferKeys'] == null ? const {} : mapWithMapOfStringsFromJson(json[r'transferKeys']),
       );
     }

--- a/lib/model/system_meta_data_owner_encrypted.dart
+++ b/lib/model/system_meta_data_owner_encrypted.dart
@@ -37,7 +37,7 @@ class SystemMetaDataOwnerEncrypted {
 
   Map<String, List<Delegation>> encryptionKeys;
 
-  Map<String, Map<String, List<String>>> aesExchangeKeys;
+  Map<String, Map<String, Map<String, String>>> aesExchangeKeys;
 
   Map<String, Map<String, String>> transferKeys;
 
@@ -52,7 +52,7 @@ class SystemMetaDataOwnerEncrypted {
           MapEquality(values: ListEquality()).equals(other.cryptedForeignKeys, cryptedForeignKeys) &&
           MapEquality(values: ListEquality()).equals(other.delegations, delegations) &&
           MapEquality(values: ListEquality()).equals(other.encryptionKeys, encryptionKeys) &&
-          MapEquality(values: MapEquality(values: ListEquality())).equals(other.aesExchangeKeys, aesExchangeKeys) &&
+          MapEquality(values: MapEquality(values: MapEquality())).equals(other.aesExchangeKeys, aesExchangeKeys) &&
           MapEquality(values: MapEquality()).equals(other.transferKeys, transferKeys);
 
   @override
@@ -114,7 +114,7 @@ class SystemMetaDataOwnerEncrypted {
         cryptedForeignKeys: json[r'cryptedForeignKeys'] == null ? const {} : Delegation.mapListFromJson(json[r'cryptedForeignKeys']),
         delegations: json[r'delegations'] == null ? const {} : Delegation.mapListFromJson(json[r'delegations']),
         encryptionKeys: json[r'encryptionKeys'] == null ? const {} : Delegation.mapListFromJson(json[r'encryptionKeys']),
-        aesExchangeKeys: json[r'aesExchangeKeys'] == null ? const {} : mapOf(json[r'aesExchangeKeys'], (el) => mapWithListOfStringsFromJson(el)),
+        aesExchangeKeys: json[r'aesExchangeKeys'] == null ? const {} : mapOf(json[r'aesExchangeKeys'], (el) => mapWithMapOfStringsFromJson(el)),
         transferKeys: json[r'transferKeys'] == null ? const {} : mapWithMapOfStringsFromJson(json[r'transferKeys']),
       );
     }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -133,7 +133,7 @@ packages:
       name: icure_dart_sdk
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   intl:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: 'icure_medical_device_dart_sdk'
 description: 'icure high level sdk for medical devices'
-version: '1.5.1'
+version: '1.5.2'
 
 homepage: 'https://icure.dev'
 
@@ -12,7 +12,7 @@ dependencies:
   intl: '^0.17.0'
   meta: '^1.7.0'
   uuid: ^3.0.5
-  icure_dart_sdk: ^1.1.1
+  icure_dart_sdk: ^1.1.2
   pointycastle: ^3.5.1
   crypton: ^2.0.3
   tuple: ^2.0.0

--- a/test/api/patient_data_owner.dart
+++ b/test/api/patient_data_owner.dart
@@ -1,0 +1,232 @@
+@Timeout(Duration(hours: 1))
+import 'dart:io';
+
+import 'package:icure_medical_device_dart_sdk/api.dart';
+import 'package:icure_medical_device_dart_sdk/utils/net_utils.dart';
+import "package:test/test.dart";
+import 'package:tuple/tuple.dart';
+import 'package:uuid/uuid.dart';
+import 'package:uuid/uuid_util.dart';
+
+import '../utils/test_utils.dart';
+
+void main() {
+  MedTechApi? hcpApi;
+  String? hcpId;
+
+  final uuid = Uuid();
+
+  setUpAll(() async {
+    final initialApi = await TestUtils.medtechApi(
+        iCureBackendUrl: Platform.environment["ICURE_URL"]!,
+        userName: Platform.environment["HCP_1_USERNAME"]!,
+        userPassword: Platform.environment["HCP_1_PASSWORD"]!,
+        userPrivKey: Platform.environment["HCP_1_PRIV_KEY"]!
+    );
+    final professionalKeys = generateRandomPrivateAndPublicKeyPair();
+    final hcp = await initialApi.healthcareProfessionalApi.createOrModifyHealthcareProfessional(
+        new HealthcareProfessional(
+            firstName: "Arthur",
+            lastName: "Dent",
+            systemMetaData: new SystemMetaDataOwner(
+                publicKey: professionalKeys.item2
+            )
+        )
+    );
+
+    final hcpUser = await initialApi.userApi.createOrModifyUser(
+        new User(
+            id: uuid.v4(options: {'rng': UuidUtil.cryptoRNG}),
+            login: "hcp-${uuid.v4(options: {'rng': UuidUtil.cryptoRNG})}-delegate",
+            status: UserStatus.ACTIVE,
+            healthcarePartyId: hcp!.id
+        )
+    );
+
+    final token = await initialApi.userApi.createToken(hcpUser!.id!);
+
+    hcpApi = await MedTechApiBuilder.newBuilder()
+        .withICureBasePath(Platform.environment["ICURE_URL"]!)
+        .withUserName(hcpUser.login!)
+        .withPassword(token!)
+        .addKeyPair(
+        hcpUser.healthcarePartyId!,
+        professionalKeys.item1.keyFromHexString()
+    )
+        .build();
+
+    hcpId = hcpUser.healthcarePartyId;
+
+    print("Successfully set up test backend!");
+  });
+
+  Future<Tuple4<Patient, DataSample, User, MedTechApi>> createPatientApi() async {
+    final patientNote = 'Premature optimization is the root of all evil';
+    final email = "${uuid.v4()}@patient-mail.com";
+    final patient = await hcpApi!.patientApi.createOrModifyPatient(
+        Patient(
+          firstName: 'John',
+          lastName: 'Doe',
+          note: patientNote,
+          addresses: [
+            Address(
+                addressType: AddressAddressTypeEnum.home,
+                description: 'London',
+                telecoms: [
+                  Telecom(
+                      telecomType: TelecomTelecomTypeEnum.email,
+                      telecomNumber: email
+                  )
+                ]
+            )
+          ],
+        )
+    );
+    final dataSample = await hcpApi!.dataSampleApi.createOrModifyDataSampleFor(patient!.id!, DataSample(
+      id: uuid.v4(options: {'rng': UuidUtil.cryptoRNG}),
+      content: {"en": Content(numberValue: 53.5)},
+      valueDate: 20220203111034,
+      labels: [CodingReference(id: "LOINC|29463-7|2", code: "29463-7", type: "LOINC", version: "2")].toSet(),
+    ));
+    final patientUser = await hcpApi!.userApi.createOrModifyUser(
+        new User(
+            id: uuid.v4(options: {'rng': UuidUtil.cryptoRNG}),
+            name: email,
+            login: email,
+            email: email,
+            status: UserStatus.ACTIVE,
+            patientId: patient.id
+        )
+    );
+    final anonApi = AnonymousMedTechApi(
+        Platform.environment["ICURE_URL"]!,
+        Platform.environment["MSG_GTW_URL"]!,
+        Platform.environment["PAT_AUTH_PROCESS_ID"]!
+    );
+    final authApi = anonApi.authenticationApi;
+    final registrationProcess = await authApi.startAuthentication(hcpId!, "Giovanni", "Muciaccia", "ArtAttack", false, email: email);
+    final validationCode = (await TestUtils.getEmailFromMsgGtw(anonApi.authServerUrl!, email)).subject;
+    final keyPair = generateRandomPrivateAndPublicKeyPair();
+    Future<Tuple3<String, String, String>?> Function(String, String) tokenAndKeyPairProvider = (String groupId, String userId) async => null;
+    final registrationResult = await authApi.completeAuthentication(registrationProcess, validationCode, keyPair, tokenAndKeyPairProvider);
+    final patUser = await retry(() => registrationResult.medTechApi.userApi.getLoggedUser());
+    assert(patUser != null);
+    assert(patUser!.patientId == patient.id!);
+    return Tuple4(
+        (await hcpApi!.patientApi.getPatient(patient.id!))!,
+        dataSample!,
+        patientUser!,
+        registrationResult.medTechApi
+    );
+  }
+
+  group('tests for patient data owners api', () {
+    test('Patient data should still be accessible to hcp after first login', () async {
+      final patientApiDetails = await createPatientApi();
+      final patient = patientApiDetails.item1;
+      final dataSample = patientApiDetails.item2;
+      final patientApi = patientApiDetails.item4;
+      expect(patientApi.patientApi.getPatient(patient.id!), throwsException);
+      final potentiallyEncryptedPatient = (await patientApi.patientApi.getPatientAndTryDecrypt(patient.id!))!;
+      expect(potentiallyEncryptedPatient is EncryptedPatient, true, reason: "Retrieved patient should be encrypted");
+      expect(potentiallyEncryptedPatient.note, null);
+      expect(potentiallyEncryptedPatient.systemMetaData?.publicKey != null, true, reason: "Patient should have initialised public key");
+
+      print("Hcp should still be able to access patient, existing data samples, and create new data samples.");
+      final retrievedPatient = (await hcpApi!.patientApi.getPatient(patient.id!))!;
+      expect(retrievedPatient.note!, patient.note);
+      expect((await hcpApi!.dataSampleApi.getDataSample(dataSample.id!))!.toJson(), dataSample.toJson());
+      final newSample = (await hcpApi!.dataSampleApi.createOrModifyDataSampleFor(patient.id!, DataSample(
+        id: uuid.v4(options: {'rng': UuidUtil.cryptoRNG}),
+        content: {"en": Content(numberValue: 159.0)},
+        valueDate: 20220203111128,
+        labels: [CodingReference(id: "LOINC|8302-2|2", code: "8302-2", type: "LOINC", version: "2")].toSet(),
+      )))!;
+      final updatedPatient = await hcpApi!.patientApi.giveAccessTo(retrievedPatient, patient.id!);
+      final updatedDataSample = await hcpApi!.dataSampleApi.giveAccessTo(dataSample, patient.id!);
+      final updatedNewSample = await hcpApi!.dataSampleApi.giveAccessTo(newSample, patient.id!);
+      expect((await hcpApi!.patientApi.getPatient(patient.id!))!.note!, patient.note);
+
+      print("Patient can now access and find all the data");
+      expect((await patientApi.patientApi.getPatient(patient.id!))!.note!, patient.note);
+      expect((await patientApi.dataSampleApi.getDataSample(dataSample.id!))!.toJson(), updatedDataSample.toJson());
+      expect((await patientApi.dataSampleApi.getDataSample(newSample.id!))!.toJson(), updatedNewSample.toJson());
+      final filterForPatient = await new DataSampleFilter()
+          .forDataOwner(patient.id!)
+          .forPatients(patientApi.crypto, [updatedPatient])
+          .build();
+      final foundDataSamplesByPatient = (await patientApi.dataSampleApi.filterDataSample(filterForPatient))!.rows;
+      expect(foundDataSamplesByPatient.length, 2);
+      expect(foundDataSamplesByPatient.map((e) => e.id!), containsAll([dataSample.id, newSample.id]));
+
+      print("And hcps should still have full access to the data");
+      expect((await hcpApi!.patientApi.getPatient(patient.id!))!.note!, patient.note);
+      expect((await hcpApi!.dataSampleApi.getDataSample(dataSample.id!))!.toJson(), updatedDataSample.toJson());
+      expect((await hcpApi!.dataSampleApi.getDataSample(newSample.id!))!.toJson(), updatedNewSample.toJson());
+      final filterForHcp = await new DataSampleFilter()
+          .forDataOwner(hcpId!)
+          .forPatients(hcpApi!.crypto, [updatedPatient])
+          .build();
+      final foundDataSamplesByHcp = (await hcpApi!.dataSampleApi.filterDataSample(filterForHcp))!.rows;
+      expect(foundDataSamplesByHcp.length, 2);
+      expect(foundDataSamplesByHcp.map((e) => e.id!), containsAll([dataSample.id, newSample.id]));
+    });
+
+    test('Patient should be able to create new data before being given full access to their existing data', () async {
+      final patientApiDetails = await createPatientApi();
+      final patient = patientApiDetails.item1;
+      final dataSample = patientApiDetails.item2;
+      final patientApi = patientApiDetails.item4;
+
+      print("Can create new sample");
+      final newSample = (await patientApi.dataSampleApi.createOrModifyDataSampleFor(patient.id!, DataSample(
+        id: uuid.v4(options: {'rng': UuidUtil.cryptoRNG}),
+        content: {"en": Content(numberValue: 159.0)},
+        valueDate: 20220203111128,
+        labels: [CodingReference(id: "LOINC|8302-2|2", code: "8302-2", type: "LOINC", version: "2")].toSet(),
+      )))!;
+
+      print("After sharing the data sample with each other both hcp and patient can directly access the data samples");
+      final updatedDataSample = await hcpApi!.dataSampleApi.giveAccessTo(dataSample, patient.id!);
+      final updatedNewSample = await patientApi.dataSampleApi.giveAccessTo(newSample, hcpId!);
+      expect((await hcpApi!.dataSampleApi.getDataSample(newSample.id!))!.toJson(), updatedNewSample.toJson());
+      expect((await patientApi.dataSampleApi.getDataSample(dataSample.id!))!.toJson(), updatedDataSample.toJson());
+
+      print("But they can only find their own data samples");
+      final filterForHcp = await new DataSampleFilter()
+          .forDataOwner(hcpId!)
+          .forPatients(hcpApi!.crypto, [patient])
+          .build();
+      final foundDataSamplesByHcp = (await hcpApi!.dataSampleApi.filterDataSample(filterForHcp))!.rows;
+      expect(foundDataSamplesByHcp.length, 1);
+      expect(foundDataSamplesByHcp[0].id, dataSample.id);
+      final filterForPatient = await new DataSampleFilter()
+          .forDataOwner(patient.id!)
+          .forPatients(patientApi.crypto, [patient])
+          .build();
+      final foundDataSamplesByPatient = (await patientApi.dataSampleApi.filterDataSample(filterForPatient))!.rows;
+      expect(foundDataSamplesByPatient.length, 1);
+      expect(foundDataSamplesByPatient[0].id, newSample.id);
+
+      print("By giving each other's access to the patient entity both patient and hcp can now find all data samples");
+      final pu0 = await hcpApi!.patientApi.getPatient(patient.id!);
+      final pu1 = await hcpApi!.patientApi.giveAccessTo(pu0!, patient.id!);
+      final updatedPatient = await patientApi.patientApi.giveAccessTo(pu1, hcpId!);
+      final filterForPatient2 = await new DataSampleFilter()
+          .forDataOwner(patient.id!)
+          .forPatients(patientApi.crypto, [updatedPatient])
+          .build();
+      final foundDataSamplesByPatient2 = (await patientApi.dataSampleApi.filterDataSample(filterForPatient2))!.rows;
+      expect(foundDataSamplesByPatient2.length, 2);
+      expect(foundDataSamplesByPatient2.map((e) => e.id), containsAll([dataSample.id, newSample.id]));
+      hcpApi!.crypto.clearCachesFor(patient.id!);
+      final filterForHcp2 = await new DataSampleFilter()
+          .forDataOwner(hcpId!)
+          .forPatients(hcpApi!.crypto, [updatedPatient])
+          .build();
+      final foundDataSamplesByHcp2 = (await hcpApi!.dataSampleApi.filterDataSample(filterForHcp2))!.rows;
+      expect(foundDataSamplesByHcp2.length, 2);
+      expect(foundDataSamplesByHcp2.map((e) => e.id), containsAll([dataSample.id, newSample.id]));
+    });
+  });
+}

--- a/test/api/patient_data_owner.dart
+++ b/test/api/patient_data_owner.dart
@@ -229,4 +229,19 @@ void main() {
       expect(foundDataSamplesByHcp2.map((e) => e.id), containsAll([dataSample.id, newSample.id]));
     });
   });
+
+  test('Patient should be able to modify his non-encrypted data even if he was not yet given full access to it', () async {
+    final patientApiDetails = await createPatientApi();
+    final patient = patientApiDetails.item1;
+    final patientApi = patientApiDetails.item4;
+    final encrypted = (await patientApi.patientApi.getPatientAndTryDecrypt(patient.id!)) as EncryptedPatient;
+    encrypted.note = "This is not allowed";
+    expect(patientApi.patientApi.modifyEncryptedPatient(encrypted), throwsArgumentError);
+    encrypted.note = null;
+    encrypted.firstName = "Gianfranco";
+    final updated = await patientApi.patientApi.modifyEncryptedPatient(encrypted);
+    expect(updated!.note, null);
+    expect(updated.firstName, "Gianfranco");
+    expect(updated.rev != encrypted.rev, true, reason: "Patient revision should have changed");
+  });
 }

--- a/test/utils/test_utils.dart
+++ b/test/utils/test_utils.dart
@@ -9,9 +9,9 @@ import 'package:uuid/uuid_util.dart';
 
 class TestUtils {
 
-  static Future<MedTechApi> medtechApi({iCureBackendUrl= "https://kraken.icure.dev", String? userName, String? userPassword, String? userPrivKey, String? authProcessHcpId}) async {
+  static Future<MedTechApi> medtechApi({String? iCureBackendUrl, String? userName, String? userPassword, String? userPrivKey, String? authProcessHcpId}) async {
     final api = MedTechApiBuilder.newBuilder()
-        .withICureBasePath(iCureBackendUrl)
+        .withICureBasePath(iCureBackendUrl ?? Platform.environment["ICURE_URL"] ?? "https://kraken.icure.dev")
         .withUserName(userName ?? Platform.environment["HCP_1_USERNAME"]!)
         .withPassword(userPassword ?? Platform.environment["HCP_1_PASSWORD"]!)
         .withAuthServerUrl(Platform.environment["MSG_GTW_URL"])


### PR DESCRIPTION
- Fix a bug that caused corruption of the `Patient` entity data the first time the new patient user logins through the authentication API.
- Includes new methods that allow new Patient users which didn't yet receive access to their existing data to still be able to create new data samples and healthcare elements